### PR TITLE
Pass hypercore as first argument to multifeed

### DIFF
--- a/problems/08.md
+++ b/problems/08.md
@@ -20,7 +20,7 @@ Make a copy of `single-chat.js` called `multichat.js`, and replace usage of `hyp
 var hypercore = require('hypercore')
 var multifeed = require('multifeed')
 
-var multi = multifeed('./multichat', {valueEncoding:'json'})
+var multi = multifeed(hypercore, './multichat', {valueEncoding:'json'})
 
 multi.writer('local', function (err, feed) {
   // TODO: join swarm

--- a/solutions/08/multichat.js
+++ b/solutions/08/multichat.js
@@ -16,7 +16,7 @@ const topicHex = crypto.createHash('sha256')
 		       .update('foobar-123')
 		       .digest()
 
-var multi = multifeed('./multichat_' + num, {
+var multi = multifeed(hypercore, './multichat_' + num, {
   valueEncoding: 'json'
 })
 


### PR DESCRIPTION
I guess the multifeed API changed between the documentation being written and now.

Even with this change, the example solution still doesn't work, I am working on fixing it.